### PR TITLE
Fix license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ license = "GPL"
 readme = "README.md"
 homepage = "https://github.com/j-a-n/python-moehlenhoff-alpha2"
 repository = "https://github.com/j-a-n/python-moehlenhoff-alpha2"
+classifiers = [
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+]
+
 
 [tool.poetry.dependencies]
 python = "^3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "moehlenhoff-alpha2"
 version = "1.3.0"
 description = "Python client for the Moehlenhoff Alpha2 underfloor heating system"
 authors = ["Jan Schneider <oss@janschneider.net>"]
-license = "GPL"
 readme = "README.md"
 homepage = "https://github.com/j-a-n/python-moehlenhoff-alpha2"
 repository = "https://github.com/j-a-n/python-moehlenhoff-alpha2"


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, and maybe bump in Home Assistant, that would be awesome :)